### PR TITLE
Call callback directly

### DIFF
--- a/library.js
+++ b/library.js
@@ -63,7 +63,7 @@
 
 	Auth0.appendUserHashWhitelist = function (data, callback) {
 		data.whitelist.push('auth0id');
-		return setImmediate(callback, null, data);
+		setImmediate(callback, null, data);
 	};
 
 	Auth0.getAssociation = function(data, callback) {


### PR DESCRIPTION
Hi,
we upgraded to NodeBB 1.17.1 (Node 14) and the forum did not start at all. The log contained this error:

```
2021-05-28T06:29:54.605Z [4567/281] - warn: [plugins] filter:user.whitelistFields already resolved in plugin nodebb-plugin-sso-auth0
(node:281) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined
    at /usr/src/app/src/database/index.js:17:24
    at Array.forEach (<anonymous>)
    at Object.primaryDB.parseIntFields (/usr/src/app/src/database/index.js:16:12)
    at /usr/src/app/src/user/data.js:159:7
    at Array.map (<anonymous>)
    at modifyUserData (/usr/src/app/src/user/data.js:154:27)
    at User.getUsersFields (/usr/src/app/src/user/data.js:78:9)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async User.getUsersData (/usr/src/app/src/user/data.js:141:10)
(Use `node --trace-warnings ...` to show where the warning was created)
```

I traced the error cause and found out that the new fire hook mechanism is not compatible with the code in this plugin.

If this is the right way how to fix this issue, the problem is probably the same in other auth plugins (for example https://github.com/julianlam/nodebb-plugin-sso-facebook/blob/master/library.js#L147 ).

Thanks,
Tomas