### PR TITLE
Fix repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "library.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/julianlam/nodebb-plugin-sso-auth0"
+    "url": "https://github.com/NodeBB-Community/nodebb-plugin-sso-auth0"
   },
   "keywords": [
     "nodebb",


### PR DESCRIPTION
Hi,
small fix to the package repository url.

[https://github.com/julianlam/nodebb-plugin-sso-auth0](https://github.com/julianlam/nodebb-plugin-sso-auth0) is no longer available and it's not easy to find this repo. F.ex. here is the wrong link [https://www.npmjs.com/package/nodebb-plugin-sso-auth0](https://www.npmjs.com/package/nodebb-plugin-sso-auth0).

Thanks,
Tomas